### PR TITLE
feat(helm) Allow specifying helm repo

### DIFF
--- a/kapitan/dependency_manager/base.py
+++ b/kapitan/dependency_manager/base.py
@@ -265,10 +265,12 @@ def fetch_helm_archive(helm_path, repo, chart_name, version, save_path):
 
     if repo.startswith("oci://"):
         args.append(repo)
-    else:
+    elif repo.startswith("https://") or repo.startswith("http://"):
         args.append("--repo")
         args.append(repo)
         args.append(chart_name)
+    else:
+        args.append(f"{repo}/{chart_name}")
 
     response = helm_cli(helm_path, args)
     if response != "":


### PR DESCRIPTION
Fixes #

## Proposed Changes

Kapitan pulls Helm charts using the helm pull command. Currently, Kapitan supports two options:

1. Providing a full chart_url, e.g., `helm pull oci://<chart_url>`
2. Providing a chart repository URL and chart name, e.g., `helm pull --repo https://charts.bitnami.com/bitnami postgresql`

However, Helm also supports pulling charts using a repository name and chart name, like: `helm pull flower-private/flower-server`

This approach is especially useful when the chart is hosted on a private registry, such as GitLab. You can add the registry with:

```
helm repo add --username <gitlab-username> --password <gitlab-pat> <repo-name> <registry-url>
```

Once added, Helm stores the credentials in its repository config file and automatically uses them for subsequent pulls. This allows us to avoid passing --username and --password to helm pull—which Kapitan currently doesn’t support configuring anyway.

## Docs and Tests

* [ ] Tests added
* [ ] Updated documentation
